### PR TITLE
docs: add logs and metrics exporters env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,18 @@ Point your instrumented application to OTEL Viewer:
 ### For HTTP (recommended)
 ```bash
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+export OTEL_LOGS_EXPORTER="otlp"
 export OTEL_TRACES_EXPORTER="otlp"
+export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
 ```
 
 ### For GRPC
 ```bash
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+export OTEL_LOGS_EXPORTER="otlp"
 export OTEL_TRACES_EXPORTER="otlp"
+export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
 ```
 

--- a/frontend/src/components/OTelExportConfig.tsx
+++ b/frontend/src/components/OTelExportConfig.tsx
@@ -22,11 +22,15 @@ export function OTelExportConfig({
   }, [hasData])
 
   const httpConfig = `export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:${httpPort}"
+export OTEL_LOGS_EXPORTER="otlp"
 export OTEL_TRACES_EXPORTER="otlp"
+export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"`
 
   const grpcConfig = `export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:${grpcPort}"
+export OTEL_LOGS_EXPORTER="otlp"
 export OTEL_TRACES_EXPORTER="otlp"
+export OTEL_METRICS_EXPORTER="otlp"
 export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"`
 
   const copyToClipboard = async (text: string, type: 'http' | 'grpc') => {


### PR DESCRIPTION
## ⚙️  Logs and Metrics Exporters Env Variables

This PR adds the environment variables necessary for sending logs and metrics to `otel-front` dashboard and `README.md`.

#### Before:

<img width="1236" height="647" alt="Screenshot 2025-11-21 at 4 53 47 PM" src="https://github.com/user-attachments/assets/6ff501cf-064c-4211-800b-016cd5fb7e9f" />

#### After:

<img width="1234" height="728" alt="Screenshot 2025-11-21 at 4 54 09 PM" src="https://github.com/user-attachments/assets/12b75653-5c3b-433d-9751-1dc9b6f24e59" />
