### PR TITLE
Fix trace summary and status display to show information from late-arriving parents

### DIFF
--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -121,7 +121,7 @@ export function TracesList() {
                         <div className="flex items-center justify-between">
                           <div className="flex items-center">
                             <div className="flex-shrink-0">
-                              {trace.has_errors ? (
+                              {trace.status_code === 2 ? (
                                 <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
                                   Error
                                 </span>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -8,7 +8,7 @@ export interface Trace {
   end_time: string
   duration_ms: number
   span_count: number
-  has_errors: boolean
+  status_code: number
 }
 
 export interface Span {

--- a/internal/exporter/traces_transformer.go
+++ b/internal/exporter/traces_transformer.go
@@ -80,13 +80,6 @@ func TransformTraces(td ptrace.Traces) ([]*store.Trace, error) {
 					trace := traces[traceID]
 					trace.SpanCount++
 
-					// If this is the root span (no parent), update the trace's operation name and service name
-					// This handles the case where child spans arrive before the root span
-					if convertedSpan.ParentSpanID == nil {
-						trace.OperationName = span.Name()
-						trace.ServiceName = serviceName
-					}
-
 					// Update start/end times
 					if convertedSpan.StartTime.Before(trace.StartTime) {
 						trace.StartTime = convertedSpan.StartTime

--- a/internal/store/traces.go
+++ b/internal/store/traces.go
@@ -86,6 +86,7 @@ func (ts *TracesStore) InsertTrace(ctx context.Context, trace *Trace) error {
 			duration_ms, span_count, error_count, status_code, attributes)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (trace_id) DO UPDATE SET
+			start_time = EXCLUDED.start_time,
 			end_time = EXCLUDED.end_time,
 			duration_ms = EXCLUDED.duration_ms,
 			span_count = EXCLUDED.span_count,
@@ -102,6 +103,29 @@ func (ts *TracesStore) InsertTrace(ctx context.Context, trace *Trace) error {
 		if err := ts.insertSpan(ctx, tx, &span); err != nil {
 			return fmt.Errorf("failed to insert span: %w", err)
 		}
+	}
+
+	// Update trace summary
+	// - local root: parent_span_id NULL or not delivered; earliest wins)
+	// - operation_name, service_name, status_code: from local root
+	_, err = tx.ExecContext(ctx, `
+		WITH local_root AS (
+			SELECT s.operation_name, s.service_name, s.status_code
+			FROM spans s
+			WHERE s.trace_id = ?
+			AND (s.parent_span_id IS NULL
+				OR s.parent_span_id NOT IN (
+					SELECT s2.span_id FROM spans s2 WHERE s2.trace_id = ?))
+			ORDER BY s.start_time ASC LIMIT 1
+		)
+		UPDATE traces SET
+			operation_name = COALESCE((SELECT operation_name FROM local_root), operation_name),
+			service_name = COALESCE((SELECT service_name FROM local_root), service_name),
+			status_code = COALESCE((SELECT status_code FROM local_root), status_code)
+		WHERE trace_id = ?
+	`, trace.TraceID, trace.TraceID, trace.TraceID)
+	if err != nil {
+		return fmt.Errorf("failed to update trace summary from spans: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/store/traces.go
+++ b/internal/store/traces.go
@@ -107,7 +107,8 @@ func (ts *TracesStore) InsertTrace(ctx context.Context, trace *Trace) error {
 
 	// Update trace summary
 	// - local root: parent_span_id NULL or not delivered; earliest wins)
-	// - operation_name, service_name, status_code: from local root
+	// - operation_name, service_name: from local root
+	// - status_code: max across all spans, Unset (0) < Ok (1) < Error (2)
 	_, err = tx.ExecContext(ctx, `
 		WITH local_root AS (
 			SELECT s.operation_name, s.service_name, s.status_code
@@ -121,9 +122,9 @@ func (ts *TracesStore) InsertTrace(ctx context.Context, trace *Trace) error {
 		UPDATE traces SET
 			operation_name = COALESCE((SELECT operation_name FROM local_root), operation_name),
 			service_name = COALESCE((SELECT service_name FROM local_root), service_name),
-			status_code = COALESCE((SELECT status_code FROM local_root), status_code)
+			status_code = COALESCE((SELECT max(s.status_code) FROM spans s WHERE s.trace_id = ?), status_code)
 		WHERE trace_id = ?
-	`, trace.TraceID, trace.TraceID, trace.TraceID)
+	`, trace.TraceID, trace.TraceID, trace.TraceID, trace.TraceID)
 	if err != nil {
 		return fmt.Errorf("failed to update trace summary from spans: %w", err)
 	}

--- a/internal/store/traces.go
+++ b/internal/store/traces.go
@@ -113,18 +113,18 @@ func (ts *TracesStore) InsertTrace(ctx context.Context, trace *Trace) error {
 		WITH local_root AS (
 			SELECT s.operation_name, s.service_name, s.status_code
 			FROM spans s
-			WHERE s.trace_id = ?
+			WHERE s.trace_id = $1
 			AND (s.parent_span_id IS NULL
 				OR s.parent_span_id NOT IN (
-					SELECT s2.span_id FROM spans s2 WHERE s2.trace_id = ?))
+					SELECT s2.span_id FROM spans s2 WHERE s2.trace_id = $1))
 			ORDER BY s.start_time ASC LIMIT 1
 		)
 		UPDATE traces SET
 			operation_name = COALESCE((SELECT operation_name FROM local_root), operation_name),
 			service_name = COALESCE((SELECT service_name FROM local_root), service_name),
-			status_code = COALESCE((SELECT max(s.status_code) FROM spans s WHERE s.trace_id = ?), status_code)
-		WHERE trace_id = ?
-	`, trace.TraceID, trace.TraceID, trace.TraceID, trace.TraceID)
+			status_code = COALESCE((SELECT max(s.status_code) FROM spans s WHERE s.trace_id = $1), status_code)
+		WHERE trace_id = $1
+	`, trace.TraceID)
 	if err != nil {
 		return fmt.Errorf("failed to update trace summary from spans: %w", err)
 	}

--- a/internal/store/traces_test.go
+++ b/internal/store/traces_test.go
@@ -336,15 +336,15 @@ func TestInsertTrace_MissingGrandparent(t *testing.T) {
 		t.Fatalf("Failed to get trace: %v", err)
 	}
 
-	// Operation/Service/Status from parent (local root)
+	// Operation/Service from local root, status from max()
 	if retrieved.OperationName != "GET /api/items" {
 		t.Errorf("Expected operation_name 'GET /api/items', got %q", retrieved.OperationName)
 	}
 	if retrieved.ServiceName != "parent-svc" {
 		t.Errorf("Expected service_name 'parent-svc', got %q", retrieved.ServiceName)
 	}
-	if retrieved.StatusCode != 0 {
-		t.Errorf("Expected status_code 0 (parent Unset), got %d", retrieved.StatusCode)
+	if retrieved.StatusCode != 1 {
+		t.Errorf("Expected status_code 1 (max of Ok=1, Unset=0), got %d", retrieved.StatusCode)
 	}
 }
 
@@ -445,8 +445,8 @@ func TestInsertTrace_LaterBatch(t *testing.T) {
 	if after2.ServiceName != "parent-svc" {
 		t.Errorf("After batch 2: expected service 'parent-svc', got %q", after2.ServiceName)
 	}
-	if after2.StatusCode != 0 {
-		t.Errorf("After batch 2: expected status_code 0 (parent Unset), got %d", after2.StatusCode)
+	if after2.StatusCode != 2 {
+		t.Errorf("After batch 2: expected status_code 2 (max of Error=2, Unset=0), got %d", after2.StatusCode)
 	}
 }
 
@@ -505,7 +505,7 @@ func TestInsertTrace_ParentsDiffer(t *testing.T) {
 		t.Fatalf("Failed to get trace: %v", err)
 	}
 
-	// Operation/Service/Status from earliest
+	// Operation/Service from earliest, status from max()
 	if retrieved.OperationName != "earlier-op" {
 		t.Errorf("Expected operation_name 'earlier-op', got %q", retrieved.OperationName)
 	}

--- a/internal/store/traces_test.go
+++ b/internal/store/traces_test.go
@@ -281,6 +281,242 @@ func TestGetServices(t *testing.T) {
 	}
 }
 
+func TestInsertTrace_MissingGrandparent(t *testing.T) {
+	store := setupTestStore(t)
+	defer store.Close()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Child span Ok (1) first, parent span Unset (0) second, parent's parent missing
+	trace := &Trace{
+		TraceID:       "trace-root-test",
+		ServiceName:   "child-svc",
+		OperationName: "SELECT db.items",
+		StartTime:     now.Add(-5 * time.Millisecond),
+		EndTime:       now,
+		DurationMs:    5,
+		SpanCount:     2,
+		ErrorCount:    0,
+		StatusCode:    0,
+		Spans: []Span{
+			{
+				SpanID:        "span-child",
+				TraceID:       "trace-root-test",
+				ParentSpanID:  strPtr("span-parent"),
+				ServiceName:   "child-svc",
+				OperationName: "SELECT db.items",
+				SpanKind:      "client",
+				StartTime:     now.Add(-3 * time.Millisecond),
+				EndTime:       now.Add(-1 * time.Millisecond),
+				DurationMs:    2,
+				StatusCode:    1,
+			},
+			{
+				SpanID:        "span-parent",
+				TraceID:       "trace-root-test",
+				ParentSpanID:  strPtr("remote-span-999"),
+				ServiceName:   "parent-svc",
+				OperationName: "GET /api/items",
+				SpanKind:      "server",
+				StartTime:     now.Add(-5 * time.Millisecond),
+				EndTime:       now,
+				DurationMs:    5,
+				StatusCode:    0,
+			},
+		},
+	}
+
+	if err := store.Traces.InsertTrace(ctx, trace); err != nil {
+		t.Fatalf("Failed to insert trace: %v", err)
+	}
+
+	retrieved, err := store.Traces.GetTraceByID(ctx, "trace-root-test")
+	if err != nil {
+		t.Fatalf("Failed to get trace: %v", err)
+	}
+
+	// Operation/Service/Status from parent (local root)
+	if retrieved.OperationName != "GET /api/items" {
+		t.Errorf("Expected operation_name 'GET /api/items', got %q", retrieved.OperationName)
+	}
+	if retrieved.ServiceName != "parent-svc" {
+		t.Errorf("Expected service_name 'parent-svc', got %q", retrieved.ServiceName)
+	}
+	if retrieved.StatusCode != 0 {
+		t.Errorf("Expected status_code 0 (parent Unset), got %d", retrieved.StatusCode)
+	}
+}
+
+func TestInsertTrace_LaterBatch(t *testing.T) {
+	store := setupTestStore(t)
+	defer store.Close()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Batch 1: child
+	batch1 := &Trace{
+		TraceID:       "trace-batch-test",
+		ServiceName:   "child-svc",
+		OperationName: "SELECT db.items",
+		StartTime:     now.Add(-3 * time.Millisecond),
+		EndTime:       now.Add(-1 * time.Millisecond),
+		DurationMs:    2,
+		SpanCount:     1,
+		ErrorCount:    0,
+		StatusCode:    0,
+		Spans: []Span{
+			{
+				SpanID:        "span-child-b",
+				TraceID:       "trace-batch-test",
+				ParentSpanID:  strPtr("span-parent-b"),
+				ServiceName:   "child-svc",
+				OperationName: "SELECT db.items",
+				SpanKind:      "client",
+				StartTime:     now.Add(-3 * time.Millisecond),
+				EndTime:       now.Add(-1 * time.Millisecond),
+				DurationMs:    2,
+				StatusCode:    2,
+			},
+		},
+	}
+
+	if err := store.Traces.InsertTrace(ctx, batch1); err != nil {
+		t.Fatalf("Failed to insert batch 1: %v", err)
+	}
+
+	after1, err := store.Traces.GetTraceByID(ctx, "trace-batch-test")
+	if err != nil {
+		t.Fatalf("Failed to get trace after batch 1: %v", err)
+	}
+
+	// child is the only span
+	if after1.OperationName != "SELECT db.items" {
+		t.Errorf("After batch 1: expected operation 'SELECT db.items', got %q", after1.OperationName)
+	}
+	if after1.ServiceName != "child-svc" {
+		t.Errorf("After batch 1: expected service 'child-svc', got %q", after1.ServiceName)
+	}
+	if after1.StatusCode != 2 {
+		t.Errorf("After batch 1: expected status_code 2 (child Error), got %d", after1.StatusCode)
+	}
+
+	// Batch 2: parent
+	batch2 := &Trace{
+		TraceID:       "trace-batch-test",
+		ServiceName:   "parent-svc",
+		OperationName: "GET /api/items",
+		StartTime:     now.Add(-5 * time.Millisecond),
+		EndTime:       now,
+		DurationMs:    5,
+		SpanCount:     2,
+		ErrorCount:    0,
+		StatusCode:    0,
+		Spans: []Span{
+			{
+				SpanID:        "span-parent-b",
+				TraceID:       "trace-batch-test",
+				ParentSpanID:  strPtr("remote-span-999"),
+				ServiceName:   "parent-svc",
+				OperationName: "GET /api/items",
+				SpanKind:      "server",
+				StartTime:     now.Add(-5 * time.Millisecond),
+				EndTime:       now,
+				DurationMs:    5,
+				StatusCode:    0,
+			},
+		},
+	}
+
+	if err := store.Traces.InsertTrace(ctx, batch2); err != nil {
+		t.Fatalf("Failed to insert batch 2: %v", err)
+	}
+
+	after2, err := store.Traces.GetTraceByID(ctx, "trace-batch-test")
+	if err != nil {
+		t.Fatalf("Failed to get trace after batch 2: %v", err)
+	}
+
+	// parent is the local root
+	if after2.OperationName != "GET /api/items" {
+		t.Errorf("After batch 2: expected operation 'GET /api/items', got %q", after2.OperationName)
+	}
+	if after2.ServiceName != "parent-svc" {
+		t.Errorf("After batch 2: expected service 'parent-svc', got %q", after2.ServiceName)
+	}
+	if after2.StatusCode != 0 {
+		t.Errorf("After batch 2: expected status_code 0 (parent Unset), got %d", after2.StatusCode)
+	}
+}
+
+func TestInsertTrace_ParentsDiffer(t *testing.T) {
+	store := setupTestStore(t)
+	defer store.Close()
+
+	ctx := context.Background()
+	now := time.Now()
+
+	// Two spans, both parents missing; earliest wins
+	trace := &Trace{
+		TraceID:       "trace-fallback-test",
+		ServiceName:   "later-svc",
+		OperationName: "later-op",
+		StartTime:     now.Add(-5 * time.Millisecond),
+		EndTime:       now,
+		DurationMs:    5,
+		SpanCount:     2,
+		ErrorCount:    0,
+		StatusCode:    0,
+		Spans: []Span{
+			{
+				SpanID:        "span-later",
+				TraceID:       "trace-fallback-test",
+				ParentSpanID:  strPtr("external-1"),
+				ServiceName:   "later-svc",
+				OperationName: "later-op",
+				SpanKind:      "server",
+				StartTime:     now.Add(-2 * time.Millisecond),
+				EndTime:       now,
+				DurationMs:    2,
+				StatusCode:    1,
+			},
+			{
+				SpanID:        "span-earlier",
+				TraceID:       "trace-fallback-test",
+				ParentSpanID:  strPtr("external-2"),
+				ServiceName:   "earlier-svc",
+				OperationName: "earlier-op",
+				SpanKind:      "server",
+				StartTime:     now.Add(-5 * time.Millisecond),
+				EndTime:       now.Add(-1 * time.Millisecond),
+				DurationMs:    4,
+				StatusCode:    2,
+			},
+		},
+	}
+
+	if err := store.Traces.InsertTrace(ctx, trace); err != nil {
+		t.Fatalf("Failed to insert trace: %v", err)
+	}
+
+	retrieved, err := store.Traces.GetTraceByID(ctx, "trace-fallback-test")
+	if err != nil {
+		t.Fatalf("Failed to get trace: %v", err)
+	}
+
+	// Operation/Service/Status from earliest
+	if retrieved.OperationName != "earlier-op" {
+		t.Errorf("Expected operation_name 'earlier-op', got %q", retrieved.OperationName)
+	}
+	if retrieved.ServiceName != "earlier-svc" {
+		t.Errorf("Expected service_name 'earlier-svc', got %q", retrieved.ServiceName)
+	}
+	if retrieved.StatusCode != 2 {
+		t.Errorf("Expected status_code 2 (earlier Error), got %d", retrieved.StatusCode)
+	}
+}
+
 func strPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
At present, the logic for whether to allow a span to become the trace headliner depends on it having no parent. But there can be cases where there is a parent referenced in a span, but for whatever reason we don't have it (http traceparent header, but no client traces, perhaps).

The waterfall correctly displays the parent-child relationships of all the spans, but the headline information for the trace can end up coming from one of the children.

This fix removes the ParentSpanID == nil test from the exporter, instead updating the trace each time a new batch of spans is processed in InsertTrace. It updates operation_name, service_name and status_code.

For status_code, rather than using the parent status_code, I suggest using the most errorful; any span with an error causes the whole trace to error. Conveniently Unset(0) < Ok(1) < Error(2), so max(error_code) works. I made that a separate commit, so its easy to exclude if you don't like it.

Also, really a different PR, but made more obvious / relevant by the suggested status_code change so fixed here: the UI tries to read has_errors, but that doesn't exist in the API. A third commit changes to using status_code, and showing the error badge when it is 2.

Three new tests for backend. TracesList and Traces aren't covered by frontend testing, so I've left it that way.