### PR TITLE
fix(receiver): handle Content-Encoding: gzip in OTLP HTTP handlers

### DIFF
--- a/internal/receiver/otlp_receiver.go
+++ b/internal/receiver/otlp_receiver.go
@@ -1,6 +1,7 @@
 package receiver
 
 import (
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -21,12 +22,12 @@ import (
 
 // OTLPReceiver receives OTLP data via HTTP and gRPC
 type OTLPReceiver struct {
-	httpPort     int
-	grpcPort     int
-	store        *store.Store
-	logger       *zap.Logger
-	httpServer   *http.Server
-	grpcServer   *grpc.Server
+	httpPort   int
+	grpcPort   int
+	store      *store.Store
+	logger     *zap.Logger
+	httpServer *http.Server
+	grpcServer *grpc.Server
 }
 
 // NewOTLPReceiver creates a new OTLP receiver
@@ -105,14 +106,34 @@ func (r *OTLPReceiver) startGRPCServer(ctx context.Context) error {
 	return r.grpcServer.Serve(lis)
 }
 
+// decompressIfNeeded wraps req.Body with a gzip reader when
+// Content-Encoding: gzip is present.
+func decompressIfNeeded(req *http.Request) (io.ReadCloser, error) {
+	if req.Header.Get("Content-Encoding") == "gzip" {
+		gr, err := gzip.NewReader(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		return gr, nil
+	}
+	return req.Body, nil
+}
+
 // handleHTTPTraces handles HTTP trace requests
 func (r *OTLPReceiver) handleHTTPTraces(w http.ResponseWriter, req *http.Request) {
-	body, err := io.ReadAll(req.Body)
+	bodyReader, err := decompressIfNeeded(req)
+	if err != nil {
+		http.Error(w, "failed to decompress body", http.StatusBadRequest)
+		r.logger.Error("Failed to decompress request body", zap.Error(err))
+		return
+	}
+	defer bodyReader.Close()
+
+	body, err := io.ReadAll(bodyReader)
 	if err != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
-	defer req.Body.Close()
 
 	// Unmarshal protobuf
 	request := ptraceotlp.NewExportRequest()
@@ -138,12 +159,19 @@ func (r *OTLPReceiver) handleHTTPTraces(w http.ResponseWriter, req *http.Request
 
 // handleHTTPLogs handles HTTP log requests
 func (r *OTLPReceiver) handleHTTPLogs(w http.ResponseWriter, req *http.Request) {
-	body, err := io.ReadAll(req.Body)
+	bodyReader, err := decompressIfNeeded(req)
+	if err != nil {
+		http.Error(w, "failed to decompress body", http.StatusBadRequest)
+		r.logger.Error("Failed to decompress request body", zap.Error(err))
+		return
+	}
+	defer bodyReader.Close()
+
+	body, err := io.ReadAll(bodyReader)
 	if err != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
-	defer req.Body.Close()
 
 	// Unmarshal protobuf
 	request := plogotlp.NewExportRequest()
@@ -169,12 +197,19 @@ func (r *OTLPReceiver) handleHTTPLogs(w http.ResponseWriter, req *http.Request) 
 
 // handleHTTPMetrics handles HTTP metric requests
 func (r *OTLPReceiver) handleHTTPMetrics(w http.ResponseWriter, req *http.Request) {
-	body, err := io.ReadAll(req.Body)
+	bodyReader, err := decompressIfNeeded(req)
+	if err != nil {
+		http.Error(w, "failed to decompress body", http.StatusBadRequest)
+		r.logger.Error("Failed to decompress request body", zap.Error(err))
+		return
+	}
+	defer bodyReader.Close()
+
+	body, err := io.ReadAll(bodyReader)
 	if err != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
-	defer req.Body.Close()
 
 	// Unmarshal protobuf
 	request := pmetricotlp.NewExportRequest()

--- a/internal/receiver/otlp_receiver.go
+++ b/internal/receiver/otlp_receiver.go
@@ -75,9 +75,9 @@ func (r *OTLPReceiver) startHTTPServer(ctx context.Context) error {
 	mux := http.NewServeMux()
 
 	// Register OTLP HTTP endpoints
-	mux.HandleFunc("/v1/traces", r.handleHTTPTraces)
-	mux.HandleFunc("/v1/logs", r.handleHTTPLogs)
-	mux.HandleFunc("/v1/metrics", r.handleHTTPMetrics)
+	mux.Handle("/v1/traces", gzipRequestMiddleware(http.HandlerFunc(r.handleHTTPTraces)))
+	mux.Handle("/v1/logs", gzipRequestMiddleware(http.HandlerFunc(r.handleHTTPLogs)))
+	mux.Handle("/v1/metrics", gzipRequestMiddleware(http.HandlerFunc(r.handleHTTPMetrics)))
 
 	r.httpServer = &http.Server{
 		Addr:    fmt.Sprintf(":%d", r.httpPort),
@@ -106,34 +106,32 @@ func (r *OTLPReceiver) startGRPCServer(ctx context.Context) error {
 	return r.grpcServer.Serve(lis)
 }
 
-// decompressIfNeeded wraps req.Body with a gzip reader when
-// Content-Encoding: gzip is present.
-func decompressIfNeeded(req *http.Request) (io.ReadCloser, error) {
-	if req.Header.Get("Content-Encoding") == "gzip" {
-		gr, err := gzip.NewReader(req.Body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+// gzipRequestMiddleware transparently decompresses request bodies when
+// Content-Encoding: gzip is present, so handlers can always read req.Body directly.
+func gzipRequestMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Encoding") == "gzip" {
+			gr, err := gzip.NewReader(r.Body)
+			if err != nil {
+				http.Error(w, "failed to decompress body", http.StatusBadRequest)
+				return
+			}
+			r.Body = gr
+			r.Header.Del("Content-Encoding")
+			r.ContentLength = -1
 		}
-		return gr, nil
-	}
-	return req.Body, nil
+		next.ServeHTTP(w, r)
+	})
 }
 
 // handleHTTPTraces handles HTTP trace requests
 func (r *OTLPReceiver) handleHTTPTraces(w http.ResponseWriter, req *http.Request) {
-	bodyReader, err := decompressIfNeeded(req)
-	if err != nil {
-		http.Error(w, "failed to decompress body", http.StatusBadRequest)
-		r.logger.Error("Failed to decompress request body", zap.Error(err))
-		return
-	}
-	defer bodyReader.Close()
-
-	body, err := io.ReadAll(bodyReader)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
+	defer req.Body.Close()
 
 	// Unmarshal protobuf
 	request := ptraceotlp.NewExportRequest()
@@ -159,19 +157,12 @@ func (r *OTLPReceiver) handleHTTPTraces(w http.ResponseWriter, req *http.Request
 
 // handleHTTPLogs handles HTTP log requests
 func (r *OTLPReceiver) handleHTTPLogs(w http.ResponseWriter, req *http.Request) {
-	bodyReader, err := decompressIfNeeded(req)
-	if err != nil {
-		http.Error(w, "failed to decompress body", http.StatusBadRequest)
-		r.logger.Error("Failed to decompress request body", zap.Error(err))
-		return
-	}
-	defer bodyReader.Close()
-
-	body, err := io.ReadAll(bodyReader)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
+	defer req.Body.Close()
 
 	// Unmarshal protobuf
 	request := plogotlp.NewExportRequest()
@@ -197,19 +188,12 @@ func (r *OTLPReceiver) handleHTTPLogs(w http.ResponseWriter, req *http.Request) 
 
 // handleHTTPMetrics handles HTTP metric requests
 func (r *OTLPReceiver) handleHTTPMetrics(w http.ResponseWriter, req *http.Request) {
-	bodyReader, err := decompressIfNeeded(req)
-	if err != nil {
-		http.Error(w, "failed to decompress body", http.StatusBadRequest)
-		r.logger.Error("Failed to decompress request body", zap.Error(err))
-		return
-	}
-	defer bodyReader.Close()
-
-	body, err := io.ReadAll(bodyReader)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
+	defer req.Body.Close()
 
 	// Unmarshal protobuf
 	request := pmetricotlp.NewExportRequest()


### PR DESCRIPTION
## Problem

When a client sends a gzip-compressed OTLP payload (with `Content-Encoding: gzip`), the HTTP receiver reads raw compressed bytes and passes them directly to `UnmarshalProto`. The gzip magic number starts with `0x1F` — its lower 3 bits equal `7`, which is not a valid protobuf wire type, causing:

```
proto: illegal wireType 7
```

## Solution

Add a `decompressIfNeeded` helper that wraps `req.Body` in a `gzip.NewReader` when `Content-Encoding: gzip` is present. Applied to all three HTTP handlers: `handleHTTPTraces`, `handleHTTPLogs`, `handleHTTPMetrics`.

## Test

```bash
# generate a gzip-compressed protobuf trace payload and send it
curl -X POST http://localhost:4318/v1/traces \
  -H "Content-Type: application/x-protobuf" \
  -H "Content-Encoding: gzip" \
  --data-binary @traces.pb.gz
```

No `Failed to unmarshal traces` error should appear in logs.