### PR TITLE
Metrics fix

### DIFF
--- a/frontend/src/hooks/useServices.ts
+++ b/frontend/src/hooks/useServices.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import { apiClient } from '../services/api'
-import type { Service } from '../types/api'
 
 export function useServices() {
   const [services, setServices] = useState<string[]>([])
@@ -12,7 +11,7 @@ export function useServices() {
     setError(null)
     apiClient
       .getServices()
-      .then((data: Service[]) => setServices(data.map((s) => s.service_name)))
+      .then((data) => setServices(data))
       .catch((err) => setError(err instanceof Error ? err : new Error('Failed to fetch services')))
       .finally(() => setLoading(false))
   }, [])

--- a/frontend/src/pages/Traces/TracesList.tsx
+++ b/frontend/src/pages/Traces/TracesList.tsx
@@ -19,7 +19,7 @@ export function TracesList() {
   useEffect(() => {
     apiClient
       .getServices()
-      .then((data) => setServices(data.map((s) => s.service_name)))
+      .then(setServices)
       .catch((err: Error) => console.error('Failed to fetch services:', err))
   }, [])
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -9,7 +9,6 @@ import type {
   MetricFilters,
   MetricAggregation,
   AggregationRequest,
-  Service,
 } from '../types/api'
 
 class ApiClient {
@@ -82,8 +81,8 @@ class ApiClient {
   }
 
   // Services
-  async getServices(): Promise<Service[]> {
-    const response = await this.client.get<{ services: Service[]; count: number }>('/services')
+  async getServices(): Promise<string[]> {
+    const response = await this.client.get<{ services: string[]; count: number }>('/services')
     return response.data.services
   }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -76,10 +76,6 @@ export interface MetricAggregation {
   unit?: string
 }
 
-export interface Service {
-  service_name: string
-}
-
 export interface TraceFilters {
   service?: string
   errors?: boolean

--- a/internal/server/handlers/metrics.go
+++ b/internal/server/handlers/metrics.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -104,14 +105,43 @@ func (h *MetricsHandler) AggregateMetrics(c *gin.Context) {
 	})
 }
 
-// GetServices returns a list of unique services
+// GetServices returns a list of unique services across traces, metrics,
+// and logs. The original implementation only queried the traces table,
+// which left the list empty when only metrics or logs were ingested.
 func (h *MetricsHandler) GetServices(c *gin.Context) {
-	services, err := h.store.Traces.GetServices(c.Request.Context())
-	if err != nil {
-		h.logger.Error("Failed to get services", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve services"})
-		return
+	ctx := c.Request.Context()
+	seen := map[string]struct{}{}
+
+	add := func(names []string) {
+		for _, n := range names {
+			if n == "" {
+				continue
+			}
+			seen[n] = struct{}{}
+		}
 	}
+
+	if names, err := h.store.Traces.GetServices(ctx); err != nil {
+		h.logger.Warn("Failed to get trace services", zap.Error(err))
+	} else {
+		add(names)
+	}
+	if names, err := h.store.Metrics.GetServices(ctx); err != nil {
+		h.logger.Warn("Failed to get metric services", zap.Error(err))
+	} else {
+		add(names)
+	}
+	if names, err := h.store.Logs.GetServices(ctx); err != nil {
+		h.logger.Warn("Failed to get log services", zap.Error(err))
+	} else {
+		add(names)
+	}
+
+	services := make([]string, 0, len(seen))
+	for n := range seen {
+		services = append(services, n)
+	}
+	sort.Strings(services)
 
 	c.JSON(http.StatusOK, gin.H{
 		"services": services,

--- a/internal/store/logs.go
+++ b/internal/store/logs.go
@@ -58,6 +58,29 @@ func (ls *LogsStore) InsertLog(ctx context.Context, log *LogRecord) error {
 	return nil
 }
 
+// GetServices returns a list of unique service names that have logs
+func (ls *LogsStore) GetServices(ctx context.Context) ([]string, error) {
+	rows, err := ls.db.QueryContext(ctx, `
+		SELECT DISTINCT service_name FROM logs
+		WHERE service_name IS NOT NULL AND service_name != ''
+		ORDER BY service_name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query log services: %w", err)
+	}
+	defer rows.Close()
+
+	services := []string{}
+	for rows.Next() {
+		var service string
+		if err := rows.Scan(&service); err != nil {
+			return nil, fmt.Errorf("failed to scan service: %w", err)
+		}
+		services = append(services, service)
+	}
+	return services, nil
+}
+
 // InsertLogs inserts multiple log records in a batch
 func (ls *LogsStore) InsertLogs(ctx context.Context, logs []LogRecord) error {
 	if len(logs) == 0 {

--- a/internal/store/metrics.go
+++ b/internal/store/metrics.go
@@ -206,6 +206,29 @@ func (ms *MetricsStore) GetMetricsCount(ctx context.Context) (int64, error) {
 }
 
 // GetMetricNames returns a list of unique metric names
+// GetServices returns a list of unique service names that have metrics
+func (ms *MetricsStore) GetServices(ctx context.Context) ([]string, error) {
+	rows, err := ms.db.QueryContext(ctx, `
+		SELECT DISTINCT service_name FROM metrics
+		WHERE service_name IS NOT NULL AND service_name != ''
+		ORDER BY service_name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query metric services: %w", err)
+	}
+	defer rows.Close()
+
+	services := []string{}
+	for rows.Next() {
+		var service string
+		if err := rows.Scan(&service); err != nil {
+			return nil, fmt.Errorf("failed to scan service: %w", err)
+		}
+		services = append(services, service)
+	}
+	return services, nil
+}
+
 func (ms *MetricsStore) GetMetricNames(ctx context.Context, serviceName string) ([]string, error) {
 	query := "SELECT DISTINCT metric_name FROM metrics"
 	args := []interface{}{}


### PR DESCRIPTION
# fix: include metric & log services in `/api/services` (and unblock the dropdown)

## Summary

The `/api/services` endpoint was wired to the `MetricsHandler` but only
queried the **traces** table. Deployments that ingest only metrics or
logs (e.g. an upstream collector forwarding `docker_stats` or Prometheus
scrapes) saw an empty list, even though the underlying data had
perfectly good `service_name` values. The frontend dropdowns that
consume `/api/services` therefore stayed empty.

This PR fixes both sides.

### Backend (Go)

- `internal/store/metrics.go` — add `MetricsStore.GetServices()`
  returning `DISTINCT service_name FROM metrics` (filtered for
  non-empty).
- `internal/store/logs.go` — add `LogsStore.GetServices()` returning
  `DISTINCT service_name FROM logs` (filtered for non-empty).
- `internal/server/handlers/metrics.go` — `GetServices` now queries
  traces, metrics, and logs, dedupes via a set, and returns a sorted
  list. Per-store errors are logged as warnings rather than failing the
  whole request, so a single broken table doesn't black-hole the
  endpoint.

API contract is unchanged: `GET /api/services` still returns
`{ "services": ["..."], "count": N }` — but the array is now a true
union across signal types.

### Frontend (TypeScript)

The frontend was incorrectly typing the response as
`{ service_name: string }[]` and calling `.map(s => s.service_name)`,
which silently produced `[undefined, ...]` and rendered an empty
dropdown. The backend has always returned `string[]`.

- `frontend/src/services/api.ts` — `getServices()` typed as
  `Promise<string[]>`; remove now-unused `Service` import.
- `frontend/src/hooks/useServices.ts` — consume the response directly
  (`.then(setServices)`); drop `Service` import and the bogus `.map`.
- `frontend/src/pages/Traces/TracesList.tsx` — same fix as
  `useServices` (this was the second caller of `apiClient.getServices()`
  and was caught by `tsc --noEmit` after the type tightening).
- `frontend/src/types/api.ts` — remove the unused `Service` interface.

## Behaviour change

- `/api/services` now reflects every signal in the store, not just
  traces.
- Service dropdowns (Traces, Logs, Metrics, Dashboard) populate
  correctly when only metrics or logs are being ingested.

## Test plan

- [x] `go build ./...` (or `go vet ./...`) on the Go side.
- [x] `npm run build` in `frontend/` — verifies the type tightening
      (no `tsc` errors).
- [x] Ingest metrics-only against the collector: `/api/services`
      returns the docker container / vLLM service names; UI dropdowns
      populate.
