### PR TITLE
Adding structured log detail drawers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@types/react-window": "^2.0.0",
         "axios": "^1.7.7",
         "chart.js": "^4.5.1",
+        "flat": "^6.0.1",
         "lucide-react": "^0.577.0",
         "react": "^18.3.1",
         "react-chartjs-2": "^5.3.1",
@@ -3050,6 +3051,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
+      "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/flat-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/react-window": "^2.0.0",
     "axios": "^1.7.7",
     "chart.js": "^4.5.1",
+    "flat": "^6.0.1",
     "lucide-react": "^0.577.0",
     "react": "^18.3.1",
     "react-chartjs-2": "^5.3.1",

--- a/frontend/src/components/Logs/LogDetailsPanel.test.tsx
+++ b/frontend/src/components/Logs/LogDetailsPanel.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { LogDetailsPanel } from './LogDetailsPanel'
+import type { Log } from '../../types/api'
+
+const baseLog: Log = {
+  id: 42,
+  trace_id: 'trace-abcdef1234567890',
+  span_id: 'span-42',
+  timestamp: '2026-05-29T12:34:56.123456Z',
+  severity: 13,
+  severity_text: 'WARN',
+  service_name: 'billing-service',
+  body: '{"message":"Payment failed","request":{"id":"req-1","status":500}}',
+  attributes: {
+    user_id: 'u-123',
+    request: {
+      headers: {
+        accept: 'application/json',
+      },
+      referer: null,
+    },
+  },
+  resource_attributes: {
+    'service.version': '1.2.3',
+    process: {
+      command_args: ['node', 'server.js'],
+    },
+  },
+}
+
+describe('LogDetailsPanel', () => {
+  it('renders log metadata and identifiers', () => {
+    render(
+      <MemoryRouter>
+        <LogDetailsPanel log={baseLog} onClose={() => {}} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: 'Payment failed' })).toBeInTheDocument()
+    expect(screen.getByText('billing-service')).toBeInTheDocument()
+    expect(screen.getByText('WARN')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByText('trace-abcdef1234567890')).toBeInTheDocument()
+    expect(screen.getByText('span-42')).toBeInTheDocument()
+  })
+
+  it('flattens nested json in the body section', () => {
+    render(
+      <MemoryRouter>
+        <LogDetailsPanel log={baseLog} onClose={() => {}} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('request.id')).toBeInTheDocument()
+    expect(screen.getByText('req-1')).toBeInTheDocument()
+    expect(screen.getByText('request.status')).toBeInTheDocument()
+    expect(screen.getByText('500')).toBeInTheDocument()
+  })
+
+  it('falls back to the raw body when the log body is not valid json', () => {
+    render(
+      <MemoryRouter>
+        <LogDetailsPanel
+          log={{
+            ...baseLog,
+            body: 'plain text body',
+            attributes: {},
+            resource_attributes: {},
+          }}
+          onClose={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: 'plain text body' })).toBeInTheDocument()
+    expect(screen.getByText('message')).toBeInTheDocument()
+    expect(screen.getAllByText('plain text body')).toHaveLength(2)
+    expect(screen.queryByText('Attributes')).not.toBeInTheDocument()
+    expect(screen.queryByText('Resource Attributes')).not.toBeInTheDocument()
+  })
+
+  it('renders attributes and resource attributes sections when present', () => {
+    render(
+      <MemoryRouter>
+        <LogDetailsPanel log={baseLog} onClose={() => {}} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Attributes')).toBeInTheDocument()
+    expect(screen.getByText('user_id')).toBeInTheDocument()
+    expect(screen.getByText('u-123')).toBeInTheDocument()
+    expect(screen.getByText('request.headers.accept')).toBeInTheDocument()
+    expect(screen.getByText('application/json')).toBeInTheDocument()
+    expect(screen.getByText('request.referer')).toBeInTheDocument()
+    expect(screen.getByText('null')).toBeInTheDocument()
+    expect(screen.getByText('Resource Attributes')).toBeInTheDocument()
+    expect(screen.getByText('service.version')).toBeInTheDocument()
+    expect(screen.getByText('1.2.3')).toBeInTheDocument()
+    expect(screen.getByText('process.command_args')).toBeInTheDocument()
+    expect(screen.getByText('["node","server.js"]')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/Logs/LogDetailsPanel.tsx
+++ b/frontend/src/components/Logs/LogDetailsPanel.tsx
@@ -1,0 +1,151 @@
+import { Check, Copy, ExternalLink, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { Log } from '../../types/api'
+import { formatTimestampPrecise } from '../../utils/format'
+import { flattenLogFields, getLogSeverityColor, parseLogBody } from '../../utils/logs'
+
+interface LogDetailsPanelProps {
+  log: Log | null
+  onClose: () => void
+}
+
+interface KeyValueSectionProps {
+  title: string
+  entries: Array<{ key: string; value: string }>
+}
+
+function KeyValueSection({ title, entries }: KeyValueSectionProps) {
+  if (entries.length === 0) return null
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-gray-700 mb-3">{title}</h3>
+      <div className="bg-gray-50 rounded-lg p-4">
+        <dl className="space-y-3">
+          {entries.map(({ key, value }) => (
+            <div key={key} className="flex flex-col">
+              <dt className="text-xs font-medium text-gray-600">{key}</dt>
+              <dd className="text-sm text-gray-900 font-mono mt-1 break-all whitespace-pre-wrap">
+                {value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  )
+}
+
+export function LogDetailsPanel({ log, onClose }: LogDetailsPanelProps) {
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const bodyDetails = useMemo(() => (log ? parseLogBody(log.body) : null), [log])
+
+  if (!log || !bodyDetails) return null
+
+  const copyToClipboard = async (text: string, field: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopiedField(field)
+      setTimeout(() => setCopiedField(null), 2000)
+    } catch (error) {
+      console.error('Failed to copy field:', error)
+    }
+  }
+
+  const identifierRows = [
+    { label: 'Log ID', value: String(log.id), field: 'log_id' },
+    ...(log.trace_id ? [{ label: 'Trace ID', value: log.trace_id, field: 'trace_id' }] : []),
+    ...(log.span_id ? [{ label: 'Span ID', value: log.span_id, field: 'span_id' }] : []),
+  ]
+
+  const attributeEntries = flattenLogFields(log.attributes ?? {})
+  const resourceEntries = flattenLogFields(log.resource_attributes ?? {})
+
+  return (
+    <div className="fixed inset-y-0 right-0 w-full sm:w-[500px] bg-white shadow-xl z-50 overflow-y-auto">
+      <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex justify-between items-start gap-4">
+        <div className="flex-1 min-w-0">
+          <h2 className="text-xl font-bold text-gray-900 break-words">{bodyDetails.title}</h2>
+          <p className="text-sm text-gray-500 mt-1">{log.service_name}</p>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="Close log details panel"
+        >
+          <X size={24} />
+        </button>
+      </div>
+
+      <div className="px-6 py-4 space-y-6">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">Severity</h3>
+          <span
+            className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getLogSeverityColor(
+              log.severity
+            )}`}
+          >
+            {log.severity_text}
+          </span>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3">Timing</h3>
+          <dl className="space-y-2">
+            <div className="flex justify-between gap-4 text-sm">
+              <dt className="text-gray-500">Timestamp</dt>
+              <dd className="text-gray-900 font-medium text-right">
+                {formatTimestampPrecise(log.timestamp)}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3">Identifiers</h3>
+          <div className="space-y-3">
+            {identifierRows.map(({ label, value, field }) => (
+              <div key={field}>
+                <div className="flex justify-between items-center mb-1">
+                  <span className="text-xs text-gray-500">{label}</span>
+                  <button
+                    onClick={() => copyToClipboard(value, field)}
+                    className="text-gray-400 hover:text-gray-600"
+                    aria-label={`Copy ${label}`}
+                  >
+                    {copiedField === field ? (
+                      <Check size={14} className="text-green-600" />
+                    ) : (
+                      <Copy size={14} />
+                    )}
+                  </button>
+                </div>
+                <code className="block text-xs font-mono bg-gray-50 p-2 rounded break-all">
+                  {value}
+                </code>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {log.trace_id && (
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700 mb-2">Correlation</h3>
+            <Link
+              to={`/traces/${log.trace_id}`}
+              className="inline-flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800"
+            >
+              <ExternalLink size={14} />
+              View related trace
+            </Link>
+          </div>
+        )}
+
+        <KeyValueSection title="Body" entries={bodyDetails.entries} />
+        <KeyValueSection title="Attributes" entries={attributeEntries} />
+        <KeyValueSection title="Resource Attributes" entries={resourceEntries} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Logs/LogTable.test.tsx
+++ b/frontend/src/components/Logs/LogTable.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LogTable } from './LogTable'
+import type { Log } from '../../types/api'
+
+const mockLog: Log = {
+  id: 101,
+  trace_id: 'trace-1234567890abcdef',
+  span_id: 'span-123',
+  timestamp: '2026-05-29T12:34:56.123456Z',
+  severity: 17,
+  severity_text: 'ERROR',
+  service_name: 'checkout-service',
+  body: 'Payment failed for order 123',
+  attributes: { env: 'prod' },
+  resource_attributes: { host: 'api-01' },
+}
+
+describe('LogTable', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  it('calls onSelectLog when a row is clicked', () => {
+    const onSelectLog = vi.fn()
+
+    render(
+      <MemoryRouter>
+        <LogTable logs={[mockLog]} onSelectLog={onSelectLog} />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /view details for log 101/i }))
+
+    expect(onSelectLog).toHaveBeenCalledWith(mockLog)
+  })
+
+  it('does not select the row when the trace link is clicked', () => {
+    const onSelectLog = vi.fn()
+
+    render(
+      <MemoryRouter>
+        <LogTable logs={[mockLog]} onSelectLog={onSelectLog} />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: /view trace/i }))
+
+    expect(onSelectLog).not.toHaveBeenCalled()
+  })
+
+  it('copies a log without selecting the row', async () => {
+    const onSelectLog = vi.fn()
+
+    render(
+      <MemoryRouter>
+        <LogTable logs={[mockLog]} onSelectLog={onSelectLog} />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByTitle(/copy log entry/i))
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        '[2026-05-29T12:34:56.123Z] [ERROR] [checkout-service] Payment failed for order 123'
+      )
+    )
+    expect(onSelectLog).not.toHaveBeenCalled()
+  })
+
+  it('highlights the selected row', () => {
+    render(
+      <MemoryRouter>
+        <LogTable logs={[mockLog]} selectedLogId={101} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('button', { name: /view details for log 101/i })).toHaveClass(
+      'bg-blue-50'
+    )
+  })
+})

--- a/frontend/src/components/Logs/LogTable.tsx
+++ b/frontend/src/components/Logs/LogTable.tsx
@@ -2,24 +2,24 @@ import { Link } from 'react-router-dom'
 import { ExternalLink, Copy, Check } from 'lucide-react'
 import { useState } from 'react'
 import type { Log } from '../../types/api'
+import { buildLogCopyText, getLogSeverityColor } from '../../utils/logs'
 
 interface LogTableProps {
   logs: Log[]
   searchQuery?: string
   onCopyLog?: (log: Log) => void
+  onSelectLog?: (log: Log) => void
+  selectedLogId?: number | null
 }
 
-export function LogTable({ logs, searchQuery, onCopyLog }: LogTableProps) {
+export function LogTable({
+  logs,
+  searchQuery,
+  onCopyLog,
+  onSelectLog,
+  selectedLogId,
+}: LogTableProps) {
   const [copiedId, setCopiedId] = useState<number | null>(null)
-
-  const getSeverityColor = (severity: number) => {
-    if (severity >= 21) return 'bg-red-600 text-white' // FATAL
-    if (severity >= 17) return 'bg-red-100 text-red-800' // ERROR
-    if (severity >= 13) return 'bg-yellow-100 text-yellow-800' // WARN
-    if (severity >= 9) return 'bg-blue-100 text-blue-800' // INFO
-    if (severity >= 5) return 'bg-gray-100 text-gray-800' // DEBUG
-    return 'bg-gray-50 text-gray-600' // TRACE
-  }
 
   const highlightText = (text: string, query?: string) => {
     if (!query || query.trim() === '') return text
@@ -41,9 +41,8 @@ export function LogTable({ logs, searchQuery, onCopyLog }: LogTableProps) {
   }
 
   const handleCopyLog = async (log: Log) => {
-    const logText = `[${new Date(log.timestamp).toISOString()}] [${log.severity_text}] [${log.service_name}] ${log.body}`
     try {
-      await navigator.clipboard.writeText(logText)
+      await navigator.clipboard.writeText(buildLogCopyText(log))
       setCopiedId(log.id)
       setTimeout(() => setCopiedId(null), 2000)
       onCopyLog?.(log)
@@ -58,9 +57,24 @@ export function LogTable({ logs, searchQuery, onCopyLog }: LogTableProps) {
     return (
       <div
         style={style}
-        className={`px-4 py-3 border-b border-gray-200 hover:bg-gray-50 ${
-          index % 2 === 0 ? 'bg-white' : 'bg-gray-50'
+        className={`px-4 py-3 border-b border-gray-200 cursor-pointer transition-colors ${
+          selectedLogId === log.id
+            ? 'bg-blue-50 ring-1 ring-inset ring-blue-200'
+            : index % 2 === 0
+            ? 'bg-white hover:bg-gray-50'
+            : 'bg-gray-50 hover:bg-gray-100'
         }`}
+        onClick={() => onSelectLog?.(log)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            onSelectLog?.(log)
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={`View details for log ${log.id}`}
+        aria-pressed={selectedLogId === log.id}
       >
         <div className="flex items-start gap-3">
           {/* Timestamp */}
@@ -77,7 +91,7 @@ export function LogTable({ logs, searchQuery, onCopyLog }: LogTableProps) {
           {/* Severity */}
           <div className="w-20 flex-shrink-0">
             <span
-              className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getSeverityColor(
+              className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getLogSeverityColor(
                 log.severity
               )}`}
             >
@@ -103,6 +117,7 @@ export function LogTable({ logs, searchQuery, onCopyLog }: LogTableProps) {
               <div className="mt-1 flex items-center gap-2">
                 <Link
                   to={`/traces/${log.trace_id}`}
+                  onClick={(event) => event.stopPropagation()}
                   className="inline-flex items-center gap-1 text-xs text-blue-600 hover:text-blue-800"
                 >
                   <ExternalLink size={12} />
@@ -118,7 +133,10 @@ export function LogTable({ logs, searchQuery, onCopyLog }: LogTableProps) {
           {/* Actions */}
           <div className="w-10 flex-shrink-0">
             <button
-              onClick={() => handleCopyLog(log)}
+              onClick={(event) => {
+                event.stopPropagation()
+                void handleCopyLog(log)
+              }}
               className="p-1 text-gray-400 hover:text-gray-600"
               title="Copy log entry"
             >

--- a/frontend/src/components/Traces/SpanDetailsPanel.tsx
+++ b/frontend/src/components/Traces/SpanDetailsPanel.tsx
@@ -1,7 +1,7 @@
 import { X, Copy, Check } from 'lucide-react'
 import { useState } from 'react'
 import type { Span } from '../../types/api'
-import { formatDurationPrecise } from '../../utils/format'
+import { formatDurationPrecise, formatTimestampPrecise } from '../../utils/format'
 
 interface SpanDetailsPanelProps {
   span: Span | null
@@ -17,23 +17,6 @@ export function SpanDetailsPanel({ span, onClose }: SpanDetailsPanelProps) {
     navigator.clipboard.writeText(text)
     setCopiedField(field)
     setTimeout(() => setCopiedField(null), 2000)
-  }
-
-  // Format timestamp with microsecond precision
-  const formatTimestamp = (timestamp: string): string => {
-    if (!timestamp) return 'N/A'
-    const date = new Date(timestamp)
-    if (isNaN(date.getTime())) return 'Invalid'
-    const time = date.toLocaleTimeString('en-US', {
-      hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit'
-    })
-    // Get microseconds from ISO string
-    const isoStr = date.toISOString()
-    const microseconds = isoStr.slice(20, 26) // Gets ".123456" part
-    return `${time}${microseconds}`
   }
 
   return (
@@ -81,11 +64,11 @@ export function SpanDetailsPanel({ span, onClose }: SpanDetailsPanelProps) {
             </div>
             <div className="flex justify-between text-sm">
               <dt className="text-gray-500">Start Time</dt>
-              <dd className="text-gray-900 font-medium">{formatTimestamp(span.start_time)}</dd>
+              <dd className="text-gray-900 font-medium">{formatTimestampPrecise(span.start_time)}</dd>
             </div>
             <div className="flex justify-between text-sm">
               <dt className="text-gray-500">End Time</dt>
-              <dd className="text-gray-900 font-medium">{formatTimestamp(span.end_time)}</dd>
+              <dd className="text-gray-900 font-medium">{formatTimestampPrecise(span.end_time)}</dd>
             </div>
           </dl>
         </div>

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -1,15 +1,31 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { FileText } from 'lucide-react'
 import { useLogs } from '../hooks/useLogs'
 import { useServices } from '../hooks/useServices'
 import { LogFiltersBar } from '../components/Logs/LogFiltersBar'
+import { LogDetailsPanel } from '../components/Logs/LogDetailsPanel'
 import { LogTable } from '../components/Logs/LogTable'
-import type { LogFilters } from '../types/api'
+import type { Log, LogFilters } from '../types/api'
 
 export function Logs() {
   const [filters, setFilters] = useState<LogFilters>({ limit: 100 })
+  const [selectedLog, setSelectedLog] = useState<Log | null>(null)
   const { logs, total, loading, error } = useLogs(filters)
   const { services } = useServices()
+
+  useEffect(() => {
+    if (!selectedLog) return
+
+    const updatedSelection = logs.find((log) => log.id === selectedLog.id)
+    if (!updatedSelection) {
+      setSelectedLog(null)
+      return
+    }
+
+    if (updatedSelection !== selectedLog) {
+      setSelectedLog(updatedSelection)
+    }
+  }, [logs, selectedLog])
 
   return (
     <div className="px-4 py-6 sm:px-0">
@@ -58,7 +74,16 @@ export function Logs() {
           </p>
         </div>
       ) : (
-        <LogTable logs={logs} searchQuery={filters.search} />
+        <LogTable
+          logs={logs}
+          searchQuery={filters.search}
+          onSelectLog={setSelectedLog}
+          selectedLogId={selectedLog?.id ?? null}
+        />
+      )}
+
+      {selectedLog && (
+        <LogDetailsPanel log={selectedLog} onClose={() => setSelectedLog(null)} />
       )}
     </div>
   )

--- a/frontend/src/pages/Traces/TraceDetail.test.tsx
+++ b/frontend/src/pages/Traces/TraceDetail.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { TraceDetail } from './TraceDetail'
+import type { Log, TraceDetail as TraceDetailType } from '../../types/api'
+
+const mockTrace: TraceDetailType = {
+  id: 'trace-1',
+  trace_id: 'trace-1',
+  service_name: 'checkout-service',
+  operation_name: 'GET /checkout',
+  start_time: '2026-05-29T12:00:00.000Z',
+  end_time: '2026-05-29T12:00:00.120Z',
+  duration_ms: 120,
+  span_count: 1,
+  status_code: 1,
+  spans: [
+    {
+      id: 1,
+      trace_id: 'trace-1',
+      span_id: 'span-1',
+      operation_name: 'GET /checkout',
+      service_name: 'checkout-service',
+      start_time: '2026-05-29T12:00:00.000Z',
+      end_time: '2026-05-29T12:00:00.120Z',
+      duration_ms: 120,
+      status_code: 'OK',
+      attributes: {
+        'http.method': 'GET',
+      },
+    },
+  ],
+}
+
+const mockLogs: Log[] = [
+  {
+    id: 55,
+    trace_id: 'trace-1',
+    span_id: 'span-1',
+    timestamp: '2026-05-29T12:00:00.050Z',
+    severity: 17,
+    severity_text: 'ERROR',
+    service_name: 'checkout-service',
+    body: '{"message":"Payment failed","error":{"code":"CARD_DECLINED"}}',
+    attributes: {
+      requestId: 'req-123',
+    },
+    resource_attributes: {
+      'service.version': '1.2.3',
+    },
+  },
+]
+
+vi.mock('../../hooks/useTraces', () => ({
+  useTrace: () => ({
+    trace: mockTrace,
+    loading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('../../hooks/useLogs', () => ({
+  useLogsByTraceId: () => ({
+    logs: mockLogs,
+    loading: false,
+    error: null,
+  }),
+}))
+
+vi.mock('../../components/Traces/WaterfallView', () => ({
+  WaterfallView: ({ onSpanClick }: { onSpanClick?: (span: (typeof mockTrace.spans)[number]) => void }) => (
+    <button onClick={() => onSpanClick?.(mockTrace.spans[0])}>Open Span</button>
+  ),
+}))
+
+vi.mock('../../components/Traces/FlameGraph', () => ({
+  FlameGraph: () => <div>Flame Graph Stub</div>,
+}))
+
+describe('TraceDetail', () => {
+  const renderPage = () =>
+    render(
+      <MemoryRouter initialEntries={['/traces/trace-1']}>
+        <Routes>
+          <Route path="/traces/:id" element={<TraceDetail />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+  it('keeps span and log panels mutually exclusive', () => {
+    renderPage()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Span' }))
+    expect(screen.getByRole('heading', { name: 'GET /checkout' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Payment failed' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /view details for related log 55/i }))
+    expect(screen.getByRole('heading', { name: 'Payment failed' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'GET /checkout' })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Span' }))
+    expect(screen.getByRole('heading', { name: 'GET /checkout' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Payment failed' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/Traces/TraceDetail.tsx
+++ b/frontend/src/pages/Traces/TraceDetail.tsx
@@ -1,12 +1,14 @@
 import { useParams, Link } from 'react-router-dom'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { BarChart3, Flame } from 'lucide-react'
 import { useTrace } from '../../hooks/useTraces'
 import { useLogsByTraceId } from '../../hooks/useLogs'
+import { LogDetailsPanel } from '../../components/Logs/LogDetailsPanel'
 import { WaterfallView } from '../../components/Traces/WaterfallView'
 import { SpanDetailsPanel } from '../../components/Traces/SpanDetailsPanel'
 import { FlameGraph } from '../../components/Traces/FlameGraph'
-import type { Span } from '../../types/api'
+import type { Log, Span } from '../../types/api'
+import { getLogSeverityColor } from '../../utils/logs'
 
 type ViewMode = 'waterfall' | 'flame'
 
@@ -16,6 +18,31 @@ export function TraceDetail() {
   const { logs } = useLogsByTraceId(id || null)
   const [viewMode, setViewMode] = useState<ViewMode>('waterfall')
   const [selectedSpan, setSelectedSpan] = useState<Span | null>(null)
+  const [selectedLog, setSelectedLog] = useState<Log | null>(null)
+
+  const handleSpanSelect = (span: Span) => {
+    setSelectedLog(null)
+    setSelectedSpan(span)
+  }
+
+  const handleLogSelect = (log: Log) => {
+    setSelectedSpan(null)
+    setSelectedLog(log)
+  }
+
+  useEffect(() => {
+    if (!selectedLog) return
+
+    const updatedSelection = logs.find((log) => log.id === selectedLog.id)
+    if (!updatedSelection) {
+      setSelectedLog(null)
+      return
+    }
+
+    if (updatedSelection !== selectedLog) {
+      setSelectedLog(updatedSelection)
+    }
+  }, [logs, selectedLog])
 
   if (loading) {
     return (
@@ -115,12 +142,12 @@ export function TraceDetail() {
 
         {/* Waterfall View */}
         {viewMode === 'waterfall' && (
-          <WaterfallView spans={trace.spans} onSpanClick={setSelectedSpan} />
+          <WaterfallView spans={trace.spans} onSpanClick={handleSpanSelect} />
         )}
 
         {/* Flame Graph View */}
         {viewMode === 'flame' && (
-          <FlameGraph spans={trace.spans} onSpanClick={setSelectedSpan} />
+          <FlameGraph spans={trace.spans} onSpanClick={handleSpanSelect} />
         )}
       </div>
 
@@ -131,18 +158,30 @@ export function TraceDetail() {
           <div className="bg-white shadow overflow-hidden sm:rounded-md">
             <ul className="divide-y divide-gray-200">
               {logs.map((log) => (
-                <li key={log.id} className="px-4 py-4 sm:px-6">
+                <li
+                  key={log.id}
+                  className={`px-4 py-4 sm:px-6 cursor-pointer transition-colors ${
+                    selectedLog?.id === log.id ? 'bg-blue-50' : 'hover:bg-gray-50'
+                  }`}
+                  onClick={() => handleLogSelect(log)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      handleLogSelect(log)
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`View details for related log ${log.id}`}
+                  aria-pressed={selectedLog?.id === log.id}
+                >
                   <div className="flex items-center justify-between">
                     <div className="flex-1">
                       <div className="flex items-center">
                         <span
-                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                            log.severity >= 17
-                              ? 'bg-red-100 text-red-800'
-                              : log.severity >= 13
-                              ? 'bg-yellow-100 text-yellow-800'
-                              : 'bg-green-100 text-green-800'
-                          }`}
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getLogSeverityColor(
+                            log.severity
+                          )}`}
                         >
                           {log.severity_text}
                         </span>
@@ -163,6 +202,10 @@ export function TraceDetail() {
       {/* Span Details Panel */}
       {selectedSpan && (
         <SpanDetailsPanel span={selectedSpan} onClose={() => setSelectedSpan(null)} />
+      )}
+
+      {selectedLog && (
+        <LogDetailsPanel log={selectedLog} onClose={() => setSelectedLog(null)} />
       )}
     </div>
   )

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -53,8 +53,8 @@ export interface Log {
   severity_text: string
   service_name: string
   body: string
-  attributes: Record<string, string>
-  resource_attributes: Record<string, string>
+  attributes: Record<string, unknown>
+  resource_attributes: Record<string, unknown>
 }
 
 export interface Metric {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -19,3 +19,25 @@ export function formatDurationPrecise(durationMs: number): string {
   }
   return `${durationMs.toFixed(3)}ms`
 }
+
+/**
+ * Format ISO timestamps with second precision plus the original fractional part when present.
+ */
+export function formatTimestampPrecise(timestamp: string): string {
+  if (!timestamp) return 'N/A'
+
+  const date = new Date(timestamp)
+  if (isNaN(date.getTime())) return 'Invalid'
+
+  const time = date.toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+
+  const fractionalMatch = timestamp.match(/\.(\d+)(?:Z|[+-]\d{2}:\d{2})?$/)
+  if (!fractionalMatch) return time
+
+  return `${time}.${fractionalMatch[1].slice(0, 6)}`
+}

--- a/frontend/src/utils/logs.ts
+++ b/frontend/src/utils/logs.ts
@@ -1,0 +1,100 @@
+import { flatten } from 'flat'
+import type { Log } from '../types/api'
+
+export interface LogFieldEntry {
+  key: string
+  value: string
+}
+
+export interface ParsedLogBody {
+  title: string
+  entries: LogFieldEntry[]
+  rawBody: string
+}
+
+const TITLE_KEYS = ['message', 'msg', 'event', 'error', 'title']
+
+function stringifyFieldValue(value: unknown): string {
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {}
+  }
+  return String(value);
+}
+
+function truncateText(text: string, maxLength = 80): string {
+  if (text.length <= maxLength) return text
+  return `${text.slice(0, maxLength - 1)}…`
+}
+
+function deriveTitleFromObject(value: Record<string, unknown>): string | null {
+  for (const key of TITLE_KEYS) {
+    const candidate = value[key]
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return truncateText(candidate.trim())
+    }
+  }
+
+  return null
+}
+
+function flattenValue(value: Record<string, unknown> | unknown[]): LogFieldEntry[] {
+  const flattened = flatten(value, { safe: true }) as Record<string, unknown>
+
+  return Object.entries(flattened).map(([key, entryValue]) => ({
+    key,
+    value: stringifyFieldValue(entryValue),
+  }))
+}
+
+export function flattenLogFields(fields: Record<string, unknown>): LogFieldEntry[] {
+  if (Object.keys(fields).length === 0) return []
+  return flattenValue(fields)
+}
+
+export function parseLogBody(body: string): ParsedLogBody {
+  try {
+    const parsed = JSON.parse(body) as unknown
+
+    if (Array.isArray(parsed)) {
+      return {
+        title: 'Structured Log',
+        entries: flattenValue(parsed),
+        rawBody: body,
+      }
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>
+
+      return {
+        title: deriveTitleFromObject(record) ?? 'Structured Log',
+        entries: flattenValue(record),
+        rawBody: body,
+      }
+    }
+  } catch {
+    // Fall back to raw body rendering below.
+  }
+
+  const rawBody = body.trim()
+  return {
+    title: rawBody ? truncateText(rawBody) : 'Log Details',
+    entries: [{ key: 'message', value: body || 'N/A' }],
+    rawBody: body,
+  }
+}
+
+export function getLogSeverityColor(severity: number): string {
+  if (severity >= 21) return 'bg-red-600 text-white'
+  if (severity >= 17) return 'bg-red-100 text-red-800'
+  if (severity >= 13) return 'bg-yellow-100 text-yellow-800'
+  if (severity >= 9) return 'bg-blue-100 text-blue-800'
+  if (severity >= 5) return 'bg-gray-100 text-gray-800'
+  return 'bg-gray-50 text-gray-600'
+}
+
+export function buildLogCopyText(log: Log): string {
+  return `[${new Date(log.timestamp).toISOString()}] [${log.severity_text}] [${log.service_name}] ${log.body}`
+}


### PR DESCRIPTION
Add right-side log detail panels to the logs view and related logs on trace detail pages.

- add a shared LogDetailsPanel with copyable identifiers and precise timestamps
- flatten structured log body, attributes, and resource attributes with flat so nested data renders clearly
- make log rows selectable and keep log/span drawers mutually exclusive on the trace detail page
- add focused tests for log panel rendering, row interaction, and trace panel exclusivity

<img width="1645" height="865" alt="log_pane" src="https://github.com/user-attachments/assets/551f95c8-4ccd-4f4a-b6d6-2fc515d17c3a" />
