### PR TITLE
fix(receiver): handle gRPC gzip encoding for OTLP

### DIFF
--- a/internal/receiver/otlp_receiver.go
+++ b/internal/receiver/otlp_receiver.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 // OTLPReceiver receives OTLP data via HTTP and gRPC


### PR DESCRIPTION
I am using otel-front with OTLP being forwarded to it from the opentelemetry-collector which expects support for gzip encoding.

#55 fixes the issue of gzip encoding for OTLP over HTTP, this PR adds support gzip encoding when using gRPC